### PR TITLE
Add getStreamItem command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 npm-debug.log
 .npmignore
+test/temp

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -70,6 +70,7 @@ module.exports = {
     listStreamItems: ["stream", {"verbose": "false"}, {"count": 10}, {"start": -10}, {"local-ordering": false}],
     listStreamPublisherItems: ["stream", "address", {"verbose": "false"}, {"count": 10}, {"start": -10}, {"local-ordering": false}],
     listStreamPublishers: ["stream", {"address": "*"}, {"verbose": "false"}, {"count": 10}, {"start": -10}, {"local-ordering": false}],
+    getStreamItem: ["stream", "txid", {"verbose": "false"}],
     //publishing stream items
     publish: ["stream", "key", "data"],
     publishFrom: ["from", "stream", "key", "data"],

--- a/test/test.js
+++ b/test/test.js
@@ -664,6 +664,13 @@ let confirmCallback4 = () => {
             verbose: true
         })
     })
+    .then(getStreamItem => {
+        console.log("TEST: GET STREAM ITEM");
+        return multichain.getStreamItemPromise({
+            stream: "stream1",
+            txid: getStreamItem[0].txid
+        })
+    })
     .then(streamPublisherItems => {
         assert(streamPublisherItems)
 


### PR DESCRIPTION
At least the getStreamItem command was missing (http://www.multichain.com/developers/json-rpc-api/).

I have not looked through to see what other commands are missing, I noticed as this is a command I need to use from multichain-node.

Can you review this pull request and we can get it merged.